### PR TITLE
Fixes for REST Clients and Multiple HTTP Methods bound to the same Path

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -204,8 +204,8 @@ function addMethod(app, callback, spec) {
   if (root && root.apis) {
     for ( var key in root.apis) {
       var api = root.apis[key];
-      if (api && api.path == spec.path) {
-        // found matching path, add & return
+      if (api && api.path == spec.path && api.method == spec.method) {
+        // found matching path and method, add & return
         appendToApi(root, api, spec);
         return;
       }
@@ -228,7 +228,7 @@ function addMethod(app, callback, spec) {
     case "GET":
       app.get(fullPath, function(req,resp){
         resp.header("Access-Control-Allow-Origin", "*");
-        resp.header("Content-Type", "application/json");
+        resp.header("Content-Type", "application/json; charset=utf-8");
         try{
           callback(req,resp);
         }
@@ -239,6 +239,7 @@ function addMethod(app, callback, spec) {
           }
           else{
             //  all others go 500
+			console.error("GET failed for path '" + fullPath + "': " + ex);
             resp.send(JSON.stringify({"description":"unknown error","code":500}))
           }
         }
@@ -247,7 +248,7 @@ function addMethod(app, callback, spec) {
     case "POST":
       app.post(fullPath, function(req,resp){
         resp.header("Access-Control-Allow-Origin", "*");
-        resp.header("Content-Type", "application/json");
+        resp.header("Content-Type", "application/json; charset=utf-8");
         try{
           callback(req,resp);
         }
@@ -258,6 +259,7 @@ function addMethod(app, callback, spec) {
           }
           else{
             //  all others go 500
+			console.error("POST failed for path '" + fullPath + "': " + ex);
             resp.send(JSON.stringify({"description":"unknown error","code":500}))
           }
         }
@@ -266,7 +268,7 @@ function addMethod(app, callback, spec) {
     case "PUT":
       app.put(fullPath, function(req,resp){
         resp.header("Access-Control-Allow-Origin", "*");
-        resp.header("Content-Type", "application/json");
+        resp.header("Content-Type", "application/json; charset=utf-8");
         try{
           callback(req,resp);
         }
@@ -277,6 +279,7 @@ function addMethod(app, callback, spec) {
           }
           else{
             //  all others go 500
+			console.error("PUT failed for path '" + fullPath + "': " + ex); 
             resp.send(JSON.stringify({"description":"unknown error","code":500}))
           }
         }
@@ -285,7 +288,7 @@ function addMethod(app, callback, spec) {
     case "DELETE":
       app.delete(fullPath, function(req,resp){
         resp.header("Access-Control-Allow-Origin", "*");
-        resp.header("Content-Type", "application/json");
+        resp.header("Content-Type", "application/json; charset=utf-8");
         try{
           callback(req,resp);
         }
@@ -296,6 +299,7 @@ function addMethod(app, callback, spec) {
           }
           else{
             //  all others go 500
+			console.error("DELETE failed for path '" + fullPath + "': " + ex);
             resp.send(JSON.stringify({"description":"unknown error","code":500}))
           }
         }


### PR DESCRIPTION
- Added charset to content-type in response header to make it compatible with various REST clients (such s the Groovy RESTClient). 
- Added additional logging for case where a non-Swagger error is caught while executing a REST method. 
- Fixed issue with logic in addMethod that prevents two different HTTP methods not he same path from being
  registered (the original behavior violates REST).  For instance, say you have the path /foo and want to register both the POST and DELETE HTTP methods on that path (which is correct for REST).  Furthermore, lets assume the following Swagger calls:

swagger.addPost(app, ...);
swagger.addDelete(app, ...);

Only the POST will be added to the "app" instance, as the DELETE will get caught in that if check and only get appended to the API and NOT registered with "app".  I am not sure what this logic was intended to do, so I am not sure that the fix is correct.  However, it got me around the issue I was seeing.
