### PR TITLE
trivial README.md edit to fix express link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is the Wordnik Swagger code for the express framework.  For more on Swagger
 
 ### To run
 
-You must first install the express module (see the [express framework site] (http://expressjs.com/guide.html):
+You must first install the express module.  See the [express framework site](http://expressjs.com/guide.html) for a guide and quick start.
 
 <pre>
 npm install express


### PR DESCRIPTION
The existing link to http://expressjs.com/guide.html includes the "):" and results in a 404 when followed.
