### PR TITLE
check validators when accessing resources.json

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -1,4 +1,3 @@
-
 var resourcePath = "/resources.json";
 var basePath = "/";
 var swaggerVersion = "1.1";
@@ -195,6 +194,12 @@ function canAccessResource(req, path, httpMethod) {
  * @param response
  */
 function resourceListing(req, res) {
+  if (!canAccessResource(req, req.url.substr(1).split('?')[0].replace('.json', '.*'), req.method)) {
+    res.send(JSON.stringify({"description":"forbidden", "code":403}), 403);
+    res.end();
+    return
+  }
+
   var r = {
     "apiVersion" : apiVersion, 
     "swaggerVersion" : swaggerVersion, 


### PR DESCRIPTION
This patch ensures that the validators are checked when called resource.json. Without this patch, anyone can see the top levels apis that your app has (through they can't actually do anything).

After applying this patch Swagger UI displays a '403 forbidden' message if the user hasn't entered a valid API key. This is less confusing than the previous behaviour, which would display the api names in grey.

Below is a screenshot which shows the difference:

![validate_resources_url](https://f.cloud.github.com/assets/862794/38669/6a0229f0-54fa-11e2-8b96-bf95044593d2.png)
