### PR TITLE
Change 'description' for 'reason' in errorParameters

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -1,3 +1,4 @@
+
 var resourcePath = "/resources.json";
 var basePath = "/";
 var swaggerVersion = "1.1";


### PR DESCRIPTION
Swagger UI doesn't display 'description' when it is rendering the ui, it only displays the 'reason' property.

This shows the problem:
![no_reason](https://f.cloud.github.com/assets/862794/39031/74747a9e-5510-11e2-94ee-760e494331aa.png)
