### PR TITLE
Fixes a bug with 500: unknown error no matter what error is thrown

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -516,19 +516,19 @@ function stopWithError(res, error) {
 exports.errors = {
   'notFound': function(field, res) { 
     if (!res) { 
-      return {"code": 404, "description": field + ' not found'}; } 
+      return {"code": 404, "reason": field + ' not found'}; } 
     else { 
       res.send({"code": 404, "description": field + ' not found'}, 404); } 
   },
   'invalid': function(field, res) { 
     if (!res) { 
-      return {"code": 400, "description": 'invalid ' + field}; } 
+      return {"code": 400, "reason": 'invalid ' + field}; } 
     else { 
       res.send({"code": 400, "description": 'invalid ' + field}, 404); } 
   },
   'forbidden': function(res) {
     if (!res) { 
-      return {"code": 403, "description": 'forbidden' }; } 
+      return {"code": 403, "reason": 'forbidden' }; } 
     else { 
       res.send({"code": 403, "description": 'forbidden'}, 403); }
   }


### PR DESCRIPTION
response handler is looking for ex.code and ex.description, but all of these errors only had 'reason' attribute. This caused every error to be treated like a 500, unknown error.
