### PR TITLE
Fix for unnecessary inherited variable in models handling

### DIFF
--- a/Apps/petstore/petResources.js
+++ b/Apps/petstore/petResources.js
@@ -10,7 +10,7 @@ function writeResponse (res, data) {
   res.send(JSON.stringify(data));
 }
 
-exports.models = require("./models.js");
+exports.models = require("./models.js").models;
 
 exports.findById = {
   'spec': {

--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -161,7 +161,7 @@ function filterApiListing(req, res, r) {
   output.models = {};
   for (var i in requiredModels){
     var modelName = requiredModels[i];
-    var model = allModels.models[modelName];
+    var model = allModels[modelName];
     if(model){
       output.models[requiredModels[i]] = model;
     }
@@ -197,7 +197,7 @@ function filterApiListing(req, res, r) {
   for (var i in requiredModels){
     var modelName = requiredModels[i];
     if(!output[modelName]) {
-      var model = allModels.models[modelName];
+      var model = allModels[modelName];
       if(model){
         output.models[requiredModels[i]] = model;
       }
@@ -412,12 +412,8 @@ function addPatch() {
 
 // adds models to swagger
 function addModels(models) {
-  if(!allModels['models']) {
-    allModels = models;
-  } else {
-    for(k in models['models']) {
-      allModels['models'][k] = models['models'][k];
-    }
+  for(var k in models) {
+    allModels[k] = models[k];
   }
   return this;
 }


### PR DESCRIPTION
``` javascript
swagger.addModels(models);
```

working not as expected and shown in README. It handles object with `models` property instead of just models object.
