### PR TITLE
Support for custom fields in operations.

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -487,6 +487,13 @@ function appendToApi(rootResource, api, spec) {
     "summary" : spec.summary
   };
   
+	// Add custom fields.
+	for (var propertyName in spec) {
+    if (!(propertyName in op)) {
+      op[propertyName] = spec[propertyName];          
+    }
+	}
+	
   if (spec.responseClass) {
     op.responseClass = spec.responseClass; 
   }


### PR DESCRIPTION
Added a loop in appendToApi that goes through the spec object and adds key-value pairs from it to the op object _if_ that op object doesn't already have that key. The result is that you can add a custom field to an operation's spec object like 'foo' and 'foo' will end up in the API docs JSON. It's handy for documenting things like example headers and for automated test tools.
