### PR TITLE
Extra route callbacks

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -550,15 +550,11 @@ function appendToApi(rootResource, api, spec) {
   };
   
 	// Add custom fields.
-	var customFields = [];
 	for (var propertyName in spec) {
     if (!(propertyName in op)) {
-			// Handlebars can't iterate over objects, but it can iterate over arrays.
-			// So, we are giving it an array of pair objects.			
-      customFields.push({name: propertyName, value: spec[propertyName]});
+			 op[propertyName] = spec[propertyName];
     }
 	}
-	op.customFields = customFields;
 	
   if (spec.responseClass) {
     op.responseClass = spec.responseClass; 


### PR DESCRIPTION
Sorry about the messiness, but there's only _one_ change in this pull request. (Commits related to custom fields have been manually rolled back by commit 4dec464.) The change is support for adding more than one callback per Express route in an API endpoint's spec. For example:

'spec': {
    'description' : 'Access an xAuth-protected resource',
    'method'      : 'POST',
   'preliminaryCallbacks': [
    passport.authenticate('consumer', {session: false}),
    passport.authenticate('local', {session: false})
  ]
}

In this example the two callbacks specified in 'preliminaryCallbacks' will be called before the main API handler. Those callbacks could potentially handle the request before the main API callback is called. This is especially useful when using passportjs strategies to authenticate API endpoints.
