### PR TITLE
Support for apis where the suffix always comes at the end of the path

### DIFF
--- a/Common/node/paramTypes.js
+++ b/Common/node/paramTypes.js
@@ -53,6 +53,19 @@ exports.body = function(name, description, dataType, defaultValue) {
   };
 };
 
+exports.form = function(name, description, dataType, required, allowMultiple, allowableValues, defaultValue) {
+  return {
+    "name" : name,
+    "description" : description,
+    "dataType" : dataType,
+    "required" : required,
+    "allowMultiple" : allowMultiple,
+    "allowableValues" : allowableValues,
+    "defaultValue" : defaultValue,
+    "paramType" : "form"
+  };
+};
+
 exports.header = function(name, description, dataType, required) {
   return {
     "name" : name,

--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -510,6 +510,8 @@ function appendToApi(rootResource, api, spec) {
         break;
       case "body":
         break;
+      case "form":
+        break;
       case "header":
         break;
       default:
@@ -600,6 +602,7 @@ exports.params = params;
 exports.queryParam = exports.params.query;
 exports.pathParam = exports.params.path;
 exports.bodyParam = exports.params.body;
+exports.formParam = exports.params.form;
 exports.getModels = allModels;
 
 exports.error = error;


### PR DESCRIPTION
Resources are not found if we specify paths like this
/users/{id}/roles.json

This fix enables that
