### PR TITLE
Add explicit support for consumes and produces parameters in spec

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -533,15 +533,17 @@ function appendToApi(rootResource, api, spec) {
     "notes" : spec.notes,
     "errorResponses" : spec.errorResponses,
     "nickname" : spec.nickname,
-    "summary" : spec.summary
+    "summary" : spec.summary,
+    "consumes" : spec.consumes,
+    "produces" : spec.produces
   };
   
 	// Add custom fields.
-	for (var propertyName in spec) {
+  for (var propertyName in spec) {
     if (!(propertyName in op)) {
       op[propertyName] = spec[propertyName];          
     }
-	}
+  }
 	
   if (spec.responseClass) {
     op.responseClass = spec.responseClass; 


### PR DESCRIPTION
Enable `consumes` to modify content-type sent by swagger-UI.

Enable `produces` to be sent to swagger-UI. As of this commit swagger-UI doesn't seem to do much with `produces`, however it is described in the 1.2 spec.

I've made these explicitly included to ensure that these parameters are passed, even if something changes in the custom parameter setters (starting line 541ish).

Please update the npm repo soon! Thanks for all your hard work!
