### PR TITLE
Adding 'preliminaryCallbacks' to a swagger route spec for better Passport integration

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -378,7 +378,7 @@ function addMethod(app, callback, spec) {
           }
         }
       }
-    });
+    }
 
     // Pass the preliminary callbacks in addition to the API callback for this route.
     var callbacks = [];


### PR DESCRIPTION
This change allows a very clean integration with passport or other auth structures. The spec is explicit and easy to read. And it moves the passport and Authentication out of the callback. We have found that we get a more uniform implementation of security it is not mixed into the final action.

Example:

```
exports.unlink = {
  "spec": {
    "description": "Remove a Cheese Linkage",
    "path": "/cheese/{id}/unlink",
    "notes": "Provides the ability to remove a cheese linkage. (Requires OAuth Signing)",
    "summary": "Remove Cheese Linkage",
    "method": "GET",
    "params": [
      sw.params.path("id", "Cheese ID", "string"),
      sw.params.query("nid", "Document ID", "string")
    ],
    "errorResponses": [
      sw.errors.invalid("id"),
      sw.errors.notFound("Cheese")
    ],
    "preliminaryCallbacks": [
      passport.authenticate("token", { session: false }),
      // or passport.authenticate("local", { session: false })
      // or something else.
    ],
    "nickname": "CheeseUnLink"
  },
  "action": function (req, res) {
    res.send("All Good")
  }
};
```

Tony, a coworker might have already requested this change. 
