### PR TITLE
Export errorHandler method

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -678,6 +678,7 @@ exports.addDELETE = addDelete;
 exports.addModels = addModels;
 exports.setAppHandler = setAppHandler;
 exports.setErrorHandler = setErrorHandler;
+exports.errorHandler = errorHandler;
 exports.discover = discover;
 exports.discoverFile = discoverFile;
 exports.configureSwaggerPaths = configureSwaggerPaths;


### PR DESCRIPTION
Exporting the errorHandler method as public API allows handling of errors in async code.

Example:
var swagger    = require("swagger-node-express");

exports.remove = {
    'spec' : {
      "description" : "Deletes an object",
      "path" : "/objects/{id}",
      "notes" : "",
      "summary" : "",
      "method" : "DELETE",
      "params" : [swagger.pathParam("id", "ID of object to delete", "string")],
      "errorResponses" : [ swagger.errors.notFound('id'), swagger.errors.invalid('id') ],
      "nickname" : "remove"
    },
    'action' : function(req, res) {

```
  if (!req.params.id) {
    throw swagger.errors.invalid('id');
  }

  req.coll.removeById(req.params.id, function(err, result) {
    if (err) {
      swagger.errorHandler(req, res, swagger.errors.invalid('collection'));
    }

    res.send({msg : 'success'});
  });
}
```

  };
