### PR TITLE
Allow swagger 'action' functions to access next() from Express.

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -678,6 +678,7 @@ exports.addDELETE = addDelete;
 exports.addModels = addModels;
 exports.setAppHandler = setAppHandler;
 exports.setErrorHandler = setErrorHandler;
+exports.errorHandler = errorHandler;
 exports.discover = discover;
 exports.discoverFile = discoverFile;
 exports.configureSwaggerPaths = configureSwaggerPaths;


### PR DESCRIPTION
To use Express middleware that does post-processing, route verbs need to declared using the midddleware syntax with the third parameter callback. An example use for this might be final formatting of the response before send is called.

Action would then have access to something like this: 

```
'action': function (req, res, next) {
  res.body = getResource();
  next();
}
```

When configuring the express middleware stack, post-processors can be defined.

```
app.use(app.router);
app.use(function (req, res, next) {
  console.log('Post-processing done here.');
  res.send(formatResponse(res));
});
```

Also, passing errors that come from asynchronous code becomes easy with next(error):
This only works if the error handler is defined in Express middleware and Swagger's error handler is set to null.

```
'action': function (req, res, next) {
  var promise = getAsyncResource(req, res);
  promise.then(function(data) {
    ....
  });
  //Calling next with an error goes right to Express error handler.
  promise.fail(function(data) {
    next(data);
  });
}
```

This change has no negative side effects, as omitting the third parameter allows for swagger to work exactly as it did before.

```
'action': function (req, res) {
  res.send(getResource());
}
```
