### PR TITLE
Allow swagger 'action' functions to access next() from Express.

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -373,7 +373,7 @@ function addMethod(app, callback, spec) {
   var fullPath = spec.path.replace(formatString, jsonSuffix).replace(/\/{/g, "/:").replace(/\}/g, "");
   var currentMethod = spec.method.toLowerCase();
   if (allowedMethods.indexOf(currentMethod) > -1) {
-    app[currentMethod](fullPath, function (req, res) {
+    app[currentMethod](fullPath, function (req, res, next) {
       exports.setHeaders(res);
 
       // todo: needs to do smarter matching against the defined paths
@@ -385,7 +385,7 @@ function addMethod(app, callback, spec) {
         }), 403);
       } else {
         try {
-          callback(req, res);
+          callback(req, res, next);
         } catch (error) {
           if (typeof errorHandler === "function") {
             errorHandler(req, res, error);


### PR DESCRIPTION
To use Express middleware that does post-processing, route verbs need to declared using the midddleware syntax with the third parameter callback. An example use for this might be final formatting of the response before send is called.

Action would then have access to something like this: 

```
'action': function (req, res, next) {
  res.body = getResource();
  next();
}
```

When configuring the express middleware stack, post-processors can be defined.

```
app.use(app.router);
app.use(function (req, res, next) {
  console.log('Post-processing done here.');
  res.send(formatResponse(res));
});
```

Also, passing errors that come from asynchronous code becomes easy with next(error):
This only works if the error handler is defined in Express middleware and Swagger's error handler is set to null.

```
'action': function (req, res, next) {
  var promise = getAsyncResource(req, res);
  promise.then(function(data) {
    ....
  });
  //Calling next with an error goes right to Express error handler.
  promise.fail(function(data) {
    next(data);
  });
}
```
#### Important

This change has no negative side effects, as omitting the third parameter allows for swagger to work exactly as it did before.

```
'action': function (req, res) {
  res.send(getResource());
}
```
