### PR TITLE
For apps which depend on next() for bubbling errors to the top, allow `swagger.errorHandler = "next"`

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -389,6 +389,8 @@ function addMethod(app, callback, spec) {
         } catch (error) {
           if (typeof errorHandler === "function") {
             errorHandler(req, res, error);
+          } else if (errorHandler === "next") {
+            next(error);
           } else {
             throw error;
           }


### PR DESCRIPTION
I don't know if this is the best way to handle this, so feel free to reject. Some apps use top-level Express error-handlers, which depend on `next(error)` to bubble the errors to the top. In particular, I'm a big fan of [domain-middleware](https://github.com/fengmk2/domain-middleware) which lets you catch both Express errors and uncaughtExceptions, making req & res available in the latter.

swagger lets you define a custom errorHandler, but because it doesn't follow the Express err-back signature of `function(err, req, res, next)`, you can't use your Express-compatible err-backs (eg, domain-middleware err-back).
