### PR TITLE
swe.notFound should have 2 params : field and res when called

### DIFF
--- a/Apps/petstore/petResources.js
+++ b/Apps/petstore/petResources.js
@@ -31,7 +31,7 @@ exports.findById = {
     var pet = petData.getPetById(id);
 
     if(pet) res.send(JSON.stringify(pet));
-    else throw swe.notFound('pet');
+    else throw swe.notFound('pet',res);
   }
 };
 


### PR DESCRIPTION
When res is not provided, it's causing an uncatched exception on my system.
