### PR TITLE
Corrected HTTP error code

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -635,7 +635,7 @@ exports.errors = {
       res.send({
         "code": 400,
         "message": 'invalid ' + field
-      }, 404);
+      }, 400);
     }
   },
   'forbidden': function (res) {


### PR DESCRIPTION
swagger.errors.invalid returned error "400" in the body while in the
HTTP header the code "404" was transmitted.
