### PR TITLE
Exporting individual params for backward compat

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,10 @@ var swagger           = require('./swagger');
 
 module.exports        = swagger;
 module.exports.params = params;
-exports.queryParam    = params.query;
-exports.pathParam     = params.path;
-exports.bodyParam     = params.body;
-exports.formParam     = params.form;
-exports.headerParam   = params.header;
-exports.error         = errorHandling.error;
+module.exports.queryParam    = params.query;
+module.exports.pathParam     = params.path;
+module.exports.bodyParam     = params.body;
+module.exports.formParam     = params.form;
+module.exports.headerParam   = params.header;
+module.exports.error         = errorHandling.error;
 

--- a/test/swagger.tests.js
+++ b/test/swagger.tests.js
@@ -3,5 +3,26 @@
 describe('swagger', function(){
   it('should be a module', function(){
     require('../');
-  });  
+  });
+  it('should have params object', function() {
+    require('../').should.have.property('params').and.should.be.type('object');
+  });
+  it('should have queryParam function', function() {
+    require('../').should.have.property('queryParam').and.should.be.type('object');
+  });
+  it('should have pathParam function', function() {
+    require('../').should.have.property('pathParam').and.should.be.type('object');
+  });
+  it('should have bodyParam function', function() {
+    require('../').should.have.property('bodyParam').and.should.be.type('object');
+  });
+  it('should have formParam function', function() {
+    require('../').should.have.property('formParam').and.should.be.type('object');
+  });
+  it('should have headerParam function', function() {
+    require('../').should.have.property('headerParam').and.should.be.type('object');
+  });
+  it('should have error function', function() {
+    require('../').should.have.property('error').and.should.be.type('object');
+  });
 });


### PR DESCRIPTION
Upgrading to swagger 2.0, the index.js file is exporting individual param types under `exports` and not `module.exports` so they're not accessible that way anymore.

```
var swagger = require('./swagger/')
console.log(swagger); //swagger exports, params
console.log(swagger.params); //q, query, path, etc
console.log(swagger.queryParam); //undefined
```

Simple change, unit tests to demonstrate.
