### PR TITLE
UI "try it out" subpath fix.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -385,7 +385,7 @@ Swagger.prototype.addMethod = function(app, callback, spec) {
   }
 
   var api = {
-    'path': (app.mountpath!="/"? app.mountpath : "") + spec.path
+    'path': (app.mountpath!=='/'? app.mountpath : '') + spec.path
   };
   if (!self.resources[apiRootPath]) {
     if (!root) {


### PR DESCRIPTION
The "Try it out!" button does not work when a sub-path is used to version APIs as specified in the swagger-node-express documentation.

For instance, the following code creates a sub-path on which to map an API:

``` javascript
var app = module.exports = express();
var subpath = express();
app.use("/v2", subpath);
swagger.setAppHandler(subpath);
...
swagger.configureSwaggerPaths("", "api-docs", "");
swagger.configure("http://localhost:9000", "2.0.0");
swaggerDir = __dirname + '/../node_modules/swagger-node-express';
var docs_handler = express.static(swaggerDir+'/swagger-ui/');
app.get(/^\/docs(\/.*)?$/, function(req, res, next) {
    if (req.url === '/docs') { // express static barfs on root url w/o trailing slash
        res.writeHead(302, { 'Location' : req.url + '/' });
        res.end();
        return;
    }
    // take off leading /docs so that connect locates file correctly
    req.url = req.url.substr('/docs'.length);
    return docs_handler(req, res, next);
});
```

Accessing docs via `http://localhost:9000/docs` gives swagger UI with default url set to `http://localhost:8002/api-docs`. After specifying `http://localhost:9000/v2/api-docs`, documentation shows up as expected. "Try it now!" works with this pull request.

Having used this package, here is some feedback:
- Swagger UI ought to be mapped automatically, without having to configure static resources or touch node_modules.
- Swagger UI should default to the API docs specified in swagger configuration: In the above example, it should default to `http://localhost:9000/v2/api-docs`, not `http://localhost:8002/api-docs`.
- There should be only one configuration function.
- Support Routers: http://expressjs.com/api.html#router

I will continue to contribute if any of the above sound like features you would like to add to the package.

Thank you for creating this package. It has saved me a great amount of time.
