### PR TITLE
Restore compatibility for 2.1.0 use of paramTypes directly from swagger

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var params            = require('./paramTypes');
 var errorHandling     = require('./errorHandling');
 var swagger           = require('./swagger');
 
-module.exports        = swagger;
+module.exports = exports = swagger;
 module.exports.params = params;
 exports.queryParam    = params.query;
 exports.pathParam     = params.path;


### PR DESCRIPTION
Fix #175 by applying same export logic as 2.1.0 in new index file.

The intention appears to be to keep compatibility but something has changed when it was moved out to an index file.  This change restores the intent.
