### PR TITLE
Support custom host and port for editor

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -46,7 +46,9 @@ app
 app
   .command('edit [directory]')
   .description('open Swagger editor for this project or the specified project directory')
-  .option('-s --silent', 'do not open the browser')
+  .option('-s, --silent', 'do not open the browser')
+  .option('--host <host>', 'the hostname the editor is served from')
+  .option('-p, --port <port>', 'the port the editor is served from')
   .action(execute(project.edit));
 
 app

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,6 +92,8 @@ Options:
 
 * -h, --help: Outputs usage information.
 * -s, --silent: Do not open the browser. 
+* --host <host>: The hostname the editor is served from (default: 127.0.0.1).
+* -p, --port <port>: The port the editor is served from (default: random port).
 
 Example:
 

--- a/lib/commands/project/swagger_editor.js
+++ b/lib/commands/project/swagger_editor.js
@@ -71,10 +71,12 @@ function edit(project, options, cb) {
 
   var http = require('http');
   var server = http.createServer(app);
-  server.listen(0, '127.0.0.1', function() {
-    var port = server.address().port;
-    var editorUrl = util.format('http://127.0.0.1:%d/#/edit', port);
-    var editApiUrl = util.format('http://127.0.0.1:%d/editor/spec', port);
+  var port = options.port || 0;
+  var hostname = options.host || '127.0.0.1';
+  server.listen(port, hostname, function() {
+    port = server.address().port;
+    var editorUrl = util.format('http://%s:%d/#/edit', hostname, port);
+    var editApiUrl = util.format('http://%s:%d/editor/spec', hostname, port);
     var dontKillMessage = 'Do not terminate this process or close this window until finished editing.';
     emit('Starting Swagger Editor.');
 

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -301,8 +301,24 @@ describe('project', function() {
       });
     });
 
-     it('edit should exec editor with --silent flag', function(done) {
+    it('edit should exec editor with --silent flag', function(done) {
       project.edit(projPath, {silent: true}, function(err) {
+        should.not.exist(err);
+        should(didEdit).true;
+        done();
+      });
+    });
+
+    it('edit should exec editor with --host parameter', function(done) {
+      project.edit(projPath, {host: 'somehost'}, function(err) {
+        should.not.exist(err);
+        should(didEdit).true;
+        done();
+      });
+    });
+
+    it('edit should exec editor with --port parameter', function(done) {
+      project.edit(projPath, {port: '8080'}, function(err) {
         should.not.exist(err);
         should(didEdit).true;
         done();

--- a/test/commands/project/swagger_editor.js
+++ b/test/commands/project/swagger_editor.js
@@ -56,6 +56,8 @@ describe('swagger editor', function() {
   var projPath;
   var swaggerFile;
   var baseUrl;
+  var hostname;
+  var port;
 
   before(function(done) {
     tmp.setGracefulCleanup();
@@ -78,6 +80,8 @@ describe('swagger editor', function() {
         url.hash = null;
         url.query = null;
         baseUrl = Url.format(url);
+        hostname = url.hostname;
+        port = url.port;
         cb(new Error());
       }
     }
@@ -101,6 +105,22 @@ describe('swagger editor', function() {
             res.text.should.equal(fileContents);
             done();
           });
+      });
+    });
+  });
+
+  it('should be able to run on a custom host and port', function(done) {
+    var fileContents = fs.readFileSync(swaggerFile, 'utf8');
+
+    project.read(projPath, {}, function(err, project) {
+      if (err) {
+        cb(err);
+      }
+
+      editor.edit(project, { host: 'localhost', port: '1234' }, function () {
+        hostname.should.equal('localhost');
+        port.should.equal('1234');
+        done();
       });
     });
   });


### PR DESCRIPTION
The Swagger editor (when using the Swagger CLI) is normally served from host "127.0.0.1" on a port which is randomly determined when the command is executed. This approach assumes that the browser is running on the same machine as the Swagger process.

In my case, I'm running Node.js and Swagger from within a Vagrant VM and Vagrant requires to define a set of specific ports which will be forwarded from the host (where the browser is running on) to the VM. So, to be able to access the editor from the browser, it is required to set a custom host and port to serve the Swagger editor from.

I've provided a PR including some tests.

This request is related to https://github.com/swagger-api/swagger-node/issues/210.