### PR TITLE
Allow passing extra arguments to node with project start command

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -35,6 +35,7 @@ app
   .option('-b, --debug-brk [port]', 'start in remote debug mode, wait for debugger connect')
   .option('-m, --mock', 'start in mock mode')
   .option('-o, --open', 'open browser as client to the project')
+  .option('-n, --node-args <args>', 'run node with extra arguments (like --node-args \"--harmony\")')
   .action(execute(project.start));
 
 app

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,7 @@ Options:
 * -b, --debug-brk <port>: Start in remote debug mode, wait for debugger. 
 * -m, --mock: Start in mock mode. For more information, see [Running in mock mode](./mock-mode.md). 
 * -o, --open: Open the default browser as a client to the project. 
+* -n, --node-args <args>: Pass extra arguments to node. E.g. `swagger project start --node-args "--harmony"` will run node with [ES6 a.k.a harmony features](https://github.com/joyent/node/wiki/ES6-%28a.k.a.-Harmony%29-Features-Implemented-in-V8-and-Available-in-Node) enabled.
 
 Example:
 

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -127,6 +127,9 @@ function start(directory, options, cb) {
       }
       nodemonOpts.nodeArgs.push(debugArg);
     }
+    if (options.nodeArgs) {
+      nodemonOpts.nodeArgs.push(options.nodeArgs)
+    }
     // https://www.npmjs.com/package/cors
     nodemonOpts.env = {
       swagger_corsOptions: '{}' // enable CORS so editor "try it" function can work

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -189,6 +189,24 @@ describe('project', function() {
       });
     });
 
+    it('should pass extra arguments', function(done) {
+      var options = { nodeArgs: '--harmony' };
+      project.start(projPath, options, function(err) {
+        should.not.exist(err);
+        nodemonOpts.nodeArgs.should.containDeep(['--harmony']);
+        done();
+      });
+    });
+
+    it('should combine extra arguments with debug', function(done) {
+      var options = { debug: true, nodeArgs: '--harmony' };
+      project.start(projPath, options, function(err) {
+        should.not.exist(err);
+        nodemonOpts.nodeArgs.should.containDeep(['--debug', '--harmony']);
+        done();
+      });
+    });
+
     it('should start in mock mode', function(done) {
       var options = { mock: true };
       project.start(projPath, options, function(err) {


### PR DESCRIPTION
I hope you find this feature useful.

In the current implementation this overrides the other nodeArgs like "debug" and "debug-brk", which is something I can approve if you intend on merging this at some point.