### PR TITLE
working branch: add cli for generating test template

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -21,6 +21,8 @@ var project = require('../lib/commands/project/project');
 var cli = require('../lib/util/cli');
 var execute = cli.execute;
 var frameworks = Object.keys(project.frameworks).join('|');
+var assertiontypes = project.assertiontypes.join('|');
+var testmodules = project.testmodules.join('|');
 
 app
   .command('create [name]')
@@ -63,6 +65,14 @@ app
   .option('-b, --debug-brk [port]', 'start in remote debug mode, wait for debugger connect')
   .option('-m, --mock', 'run in mock mode')
   .action(execute(project.test));
+  
+app 
+  .command('generate-test [directory]')
+  .description('Generate the test template')
+  .option('-p, --path-name [path]', 'a sepecific path of the api, also suppport regular expression')
+  .option('-f, --test-module <module>', 'one of: ' + testmodules)
+  .option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
+  .action(execute(project.generateTest));
 
 app.parse(process.argv);
 cli.validate(app);

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -24,6 +24,9 @@ var netutil = require('../../util/net');
 var debug = require('debug')('swagger');
 var util = require('util');
 var cli = require('../../util/cli');
+var template = require('swagger-test-templates');
+var async = require('async');
+var swaggerSpec = require('../../util/spec');
 
 var FRAMEWORKS = {
   connect: { source: 'connect' },
@@ -32,6 +35,9 @@ var FRAMEWORKS = {
   restify: { source: 'connect', overlay: 'restify' },
   sails:   { source: 'sails' }
 };
+
+var ASSERTIONTYPES = ['expect', 'should', 'assert'];
+var TESTMODULES = ['supertest', 'request'];
 
 module.exports = {
   create: create,
@@ -43,12 +49,16 @@ module.exports = {
 
   // for internal use
   frameworks: FRAMEWORKS,
-  read: readProject
+  read: readProject,
+  assertiontypes: ASSERTIONTYPES,
+  testmodules: TESTMODULES,
+ 
+  // for testing stub generating
+  generateTest: testGenerate
 };
 
 //.option('-f, --framework <framework>', 'one of: connect | express')
 function create(name, options, cb) {
-
   function validateName(name) {
     var targetDir = path.resolve(process.cwd(), name);
     if (fs.existsSync(targetDir)) {
@@ -200,7 +210,6 @@ function test(directory, options, cb) {
 }
 
 function verify(directory, options, cb) {
-  var swaggerSpec = require('../../util/spec');
 
   readProject(directory, options, function(err, project) {
     if (err) { return cb(err); }
@@ -361,5 +370,58 @@ function spawn(command, options, cwd, cb) {
   });
   npm.on('error', function(err) {
     cb(err);
+  });
+}
+
+
+//.option('-p, --path-name [path]', 'a sepecific path of the api')
+//.option('-f, --test-module <module>', 'one of: ' + testmodules)
+//.option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
+function testGenerate(directory, options, cb) {
+  var pathList = [];
+  var desiredPaths = [];
+  var testModule = options.testModule || TESTMODULES[0];
+  var assertionFormat = options.assertionFormat || ASSERTIONTYPES[0];
+
+  //read the yaml file and validate it
+  readProject(directory, options, function(err, project) {
+    if (err) { return cb(err); }
+    swaggerSpec.validateSwagger(project.api.swagger, options, function(err) {
+      // get the array of string paths from json object
+      pathList = Object.keys(project.api.swagger.paths);
+
+      //check if the test frame is one of the two
+      if (options.testModule && !_.includes(TESTMODULES, options.testModule)) {
+        return cb(new Error(util.format('Unknown type: %j. Valid types: %s', options.testModule, TESTMODULES.join(', '))));
+      }
+
+      // check if the assertion-format is one of the three
+      if (options.assertionFormat && !_.includes(ASSERTIONTYPES, options.assertionFormat)) {
+        return cb(new Error(util.format('Unknown type: %j. Valid types: %s', options.assertionFormat, ASSERTIONTYPES.join(', '))));
+      }
+
+      // process the paths option
+      if (options.pathName){
+        var reg = new RegExp(options.pathName);
+        desiredPaths = pathList.filter(function(val) {
+          return val.match(reg);
+        });
+      }
+
+      // pass the config to the module and get the result string array
+      var config = {
+        pathName: desiredPaths,
+        testModule: testModule,
+        assertionFormat: assertionFormat
+      };
+
+      var result = template.testGen(project.api.swagger, config);
+      //output the result
+      async.eachSeries(result, function (item, cb) {
+        var p = item.name;
+        var filename = p.substring(1);
+        fs.outputFile(path.join(directory + '/test', filename), item.test, cb);
+      }, cb);
+    });
   });
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "nodemon": "^1.3.7",
     "serve-static": "^1.9.2",
     "swagger-editor": "^2.9.2",
-    "swagger-tools": "^0.8.6"
+    "swagger-tools": "^0.8.6",
+    "async": "^1.2.1",
+    "swagger-test-templates": "gi0.0.0-alpha"
   },
   "devDependencies": {
     "superagent": "^1.1.0",

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -334,4 +334,59 @@ describe('project', function() {
     });
   });
 
+
+  describe('generate-test', function() {
+
+    var name = 'generate-test';
+    var projPath;
+
+    before(function(done) {
+      projPath = path.resolve(tmpDir, name);
+      process.chdir(tmpDir);
+      project.create(name, { framework: 'connect' }, done);
+    });
+
+
+    it('should pass test-module options', function(done) {
+      var options = { testModule: 'request' };
+      project.generateTest(projPath, options, function(err) {
+        should.not.exist(err);
+        fs.existsSync(path.resolve(projPath, 'test/helloStub.js')).should.be.ok;
+        done();
+      });
+    });
+
+    it('should err when given invalid test-module options', function(done) {
+      var options = { testModule: 'wrong'};
+      project.generateTest(projPath, options, function(err) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('should pass assertion-format options', function(done) {
+      var options = { assertionFormat: "expect" };
+      project.generateTest(projPath, options, function(err) {
+        fs.existsSync(path.resolve(projPath, 'test/helloStub.js')).should.be.ok;
+        done();
+      });
+    });
+
+    it('should err when given invalid assertion-format options', function(done) {
+      var options = {assertionFormat: 'wrong'};
+      project.generateTest(projPath, options, function(err) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('should generate testing stubs for the project successfully', function(done) {
+      var options = {pathName: '.*'};
+      project.generateTest(projPath, options, function(err) {
+        fs.existsSync(path.resolve(projPath, 'test/helloStub.js')).should.be.ok;
+        done();
+      })
+    });
+  });
+
 });


### PR DESCRIPTION
implement the testGenerate function in the controller

complete the output feature

update the output function

update the config object

add the framework option

update testGenerate function

add options for asyn/syn, file structure

fix the bug in project.js, change expect to request

fix a typo seperate -> separate

change the output file name

change the dictionaries to array in project.js

remove seperate and asynchronous options and change testmodule to test-module

guard against invalid yaml and invalid swagger

use readProject to load yaml file and validate it

use array.prototype.filter to filter desired path

remove quotes for key names

use async library to process the returned array, and output files

add handle bar module

add a newline of the file

use loadash to check the values in the array

add template module to json, change the dictionary to array

delete redunt regStr

change Start to start in bin/swagger-project.js

change to
0.0.0-alpha

change the hard code value

add tests for generate-test

update testing for generate-test

update testing for generare-test

fixed the bugs in project.js

fixed conflicts in readme.md