### PR TITLE
Run all tests instead of a single test group

### DIFF
--- a/test/project-skeletons/connect.js
+++ b/test/project-skeletons/connect.js
@@ -95,7 +95,7 @@ describe(framework + ' project', function() {
     });
   });
 
-  describe.only('/swagger should respond', function() {
+  describe('/swagger should respond', function() {
 
     it('with json', function(done) {
       request(server)


### PR DESCRIPTION
I think this `.only` call is committed by accident