### PR TITLE
Add `swagger project generate-test` command

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -21,6 +21,8 @@ var project = require('../lib/commands/project/project');
 var cli = require('../lib/util/cli');
 var execute = cli.execute;
 var frameworks = Object.keys(project.frameworks).join('|');
+var assertiontypes = project.assertiontypes.join('|');
+var testmodules = project.testmodules.join('|');
 
 app
   .command('create [name]')
@@ -64,6 +66,14 @@ app
   .option('-b, --debug-brk [port]', 'start in remote debug mode, wait for debugger connect')
   .option('-m, --mock', 'run in mock mode')
   .action(execute(project.test));
+  
+app 
+  .command('generate-test [directory]')
+  .description('Generate the test template')
+  .option('-p, --path-name [path]', 'a sepecific path of the api, also suppport regular expression')
+  .option('-f, --test-module <module>', 'one of: ' + testmodules)
+  .option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
+  .action(execute(project.generateTest));
 
 app.parse(process.argv);
 cli.validate(app);

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -24,6 +24,10 @@ var netutil = require('../../util/net');
 var debug = require('debug')('swagger');
 var util = require('util');
 var cli = require('../../util/cli');
+var template = require('swagger-test-templates');
+var async = require('async');
+var swaggerSpec = require('../../util/spec');
+var spec = require('swagger-tools').specs.v2;
 
 var FRAMEWORKS = {
   connect: { source: 'connect' },
@@ -32,6 +36,9 @@ var FRAMEWORKS = {
   restify: { source: 'connect', overlay: 'restify' },
   sails:   { source: 'sails' }
 };
+
+var ASSERTIONTYPES = ['expect', 'should', 'assert'];
+var TESTMODULES = ['supertest', 'request'];
 
 module.exports = {
   create: create,
@@ -43,12 +50,16 @@ module.exports = {
 
   // for internal use
   frameworks: FRAMEWORKS,
-  read: readProject
+  read: readProject,
+  assertiontypes: ASSERTIONTYPES,
+  testmodules: TESTMODULES,
+
+  // for testing stub generating
+  generateTest: testGenerate
 };
 
 //.option('-f, --framework <framework>', 'one of: connect | express')
 function create(name, options, cb) {
-
   function validateName(name) {
     var targetDir = path.resolve(process.cwd(), name);
     if (fs.existsSync(targetDir)) {
@@ -85,13 +96,10 @@ function create(name, options, cb) {
     cloneSkeleton(name, framework, targetDir, function(err) {
       if (err) { return cb(err); }
       emit('Project %s created in %s', name, targetDir);
-      spawn('npm', ['install'], targetDir, function(err) {
-        if (err) {
-          emit('"npm install" failed. Please run "npm install" in %s.', targetDir);
-          return cb(err);
-        }
-        cb(null, util.format('Success! You may start your new app by running: "swagger project start %s"', name));
-      });
+
+      var message = util.format('Success! You may start your new app by running: "swagger project start %s"', name);
+
+      installDependencies(targetDir, message, cb);
     });
   });
 }
@@ -209,7 +217,6 @@ function test(directory, options, cb) {
 }
 
 function verify(directory, options, cb) {
-  var swaggerSpec = require('../../util/spec');
 
   readProject(directory, options, function(err, project) {
     if (err) { return cb(err); }
@@ -370,5 +377,111 @@ function spawn(command, options, cwd, cb) {
   });
   npm.on('error', function(err) {
     cb(err);
+  });
+}
+
+
+//.option('-p, --path-name [path]', 'a sepecific path of the api')
+//.option('-f, --test-module <module>', 'one of: ' + testmodules)
+//.option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
+function testGenerate(directory, options, cb) {
+  var pathList = [];
+  var desiredPaths = [];
+  var testModule = options.testModule || TESTMODULES[0];
+  var assertionFormat = options.assertionFormat || ASSERTIONTYPES[0];
+
+  findProjectFile(directory, null, function(err, projPath) {
+    var projectFile;
+    var projectJson = require(projPath);
+    var runInstall = false;
+
+    if (!projectJson.devDependencies.hasOwnProperty('z-schema')) {
+      projectJson.devDependencies['z-schema'] = '^3.12.0';
+      runInstall = true;
+    }
+
+    if (!projectJson.devDependencies.hasOwnProperty('request')) {
+      projectJson.devDependencies.request = '^2.58.0';
+      runInstall = true;
+    }
+
+    if (!projectJson.devDependencies.hasOwnProperty('chai')) {
+      projectJson.devDependencies.chai = '^3.0.0';
+      runInstall = true;
+    }
+
+    if (!projectJson.devDependencies.hasOwnProperty('mocha')) {
+      projectJson.devDependencies.mocha = '^2.2.5';
+      runInstall = true;
+    }
+
+    if (!projectJson.hasOwnProperty('scripts')) {
+      projectJson.scripts = {test: 'mocha test'};
+    } else if (!projectJson.scripts.hasOwnProperty('test')) {
+      projectJson.scripts.test = 'mocha test';
+    }
+
+    projectFile = JSON.stringify(projectJson, null, 2);
+
+    fs.writeFileSync(projPath, projectFile);
+
+    if (runInstall) {
+      installDependencies(directory, 'Success! You may now run your tests.', cb);
+    }
+
+    //read the yaml file and validate it
+    readProject(directory, options, function(err, project) {
+      if (err) { return cb(err); }
+      swaggerSpec.validateSwagger(project.api.swagger, options, function(err) {
+        spec.resolve(project.api.swagger, function(err, result) {
+          // get the array of string paths from json object
+          pathList = Object.keys(result.paths);
+
+          //check if the test frame is one of the two
+          if (options.testModule && !_.includes(TESTMODULES, options.testModule)) {
+            return cb(new Error(util.format('Unknown type: %j. Valid types: %s', options.testModule, TESTMODULES.join(', '))));
+          }
+
+          // check if the assertion-format is one of the three
+          if (options.assertionFormat && !_.includes(ASSERTIONTYPES, options.assertionFormat)) {
+            return cb(new Error(util.format('Unknown type: %j. Valid types: %s', options.assertionFormat, ASSERTIONTYPES.join(', '))));
+          }
+
+          // process the paths option
+          if (options.pathName){
+            var reg = new RegExp(options.pathName);
+            desiredPaths = pathList.filter(function(val) {
+              return val.match(reg);
+            });
+          }
+
+          // pass the config to the module and get the result string array
+          var config = {
+            pathName: desiredPaths,
+            testModule: testModule,
+            assertionFormat: assertionFormat
+          };
+          var finalResult = template.testGen(result, config);
+
+          //output the result
+          directory = directory || process.cwd();
+          async.each(finalResult, function (item, callback) {
+            fs.outputFile(path.join(directory, '/test', item.name), item.test, callback);
+          }, cb);
+        });
+      });
+    });
+  });
+
+
+}
+
+function installDependencies(directory, message, cb) {
+  spawn('npm', ['install'], directory, function(err) {
+    if (err) {
+      emit('"npm install" failed. Please run "npm install" in %s.', directory);
+      return cb(err);
+    }
+    cb(null, message);
   });
 }

--- a/package.json
+++ b/package.json
@@ -29,14 +29,19 @@
     "nodemon": "^1.3.7",
     "serve-static": "^1.9.2",
     "swagger-editor": "^2.9.2",
-    "swagger-tools": "^0.9.0"
+    "swagger-tools": "^0.9.0",
+    "async": "^1.2.1",
+    "swagger-test-templates": "^0.1.1"
   },
   "devDependencies": {
     "superagent": "^1.1.0",
     "supertest": "^0.15.0",
     "should": "^5.2.0",
     "proxyquire": "^1.4.0",
-    "tmp": "^0.0.25"
+    "tmp": "^0.0.25",
+    "z-schema": "^3.12.0",
+    "chai": "^3.0.0",
+    "mocha": "^2.2.5"
   },
   "scripts": {
     "test": "mocha -u exports -R spec test/config.js test/util test/commands test/commands/project test/project-skeletons",

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -352,4 +352,86 @@ describe('project', function() {
     });
   });
 
+
+  describe('generate-test', function() {
+
+    var name = 'generate-test';
+    var projPath;
+
+    before(function(done) {
+      projPath = path.resolve(tmpDir, name);
+      process.chdir(tmpDir);
+      project.create(name, { framework: 'connect' }, done);
+    });
+
+    it('should err when given invalid test-module options', function(done) {
+      var options = { testModule: 'wrong'};
+      project.generateTest(projPath, options, function(err) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('should pass test-module options', function(done) {
+      var options = { testModule: 'request'  };
+      project.generateTest(projPath, options, function(err) {
+        fs.existsSync(path.resolve(projPath, 'test/hello-test.js')).should.be.ok;
+        var packagePath = path.resolve(projPath, 'package.json');
+        fs.existsSync(packagePath).should.be.ok;
+        var packageJson = require(packagePath);
+        packageJson.devDependencies.hasOwnProperty('z-schema').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('request').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('chai').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('mocha').should.be.ok;
+        packageJson.hasOwnProperty('scripts').should.be.ok;
+        packageJson.scripts.hasOwnProperty('test').should.be.ok;
+        done(err);
+      });
+
+    });
+
+    it('should pass assertion fotmat options', function(done) {
+      var options = { assertionFormat: 'expect'  };
+      project.generateTest(projPath, options, function(err) {
+        fs.existsSync(path.resolve(projPath, 'test/hello-test.js')).should.be.ok;
+        var packagePath = path.resolve(projPath, 'package.json');
+        fs.existsSync(packagePath).should.be.ok;
+        var packageJson = require(packagePath);
+        packageJson.devDependencies.hasOwnProperty('z-schema').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('request').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('chai').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('mocha').should.be.ok;
+        packageJson.hasOwnProperty('scripts').should.be.ok;
+        packageJson.scripts.hasOwnProperty('test').should.be.ok;
+        done();
+      });
+    });
+
+
+    it('should err when given invalid assertion-format options', function(done) {
+      var options = {assertionFormat: 'wrong'};
+      project.generateTest(projPath, options, function(err) {
+        should.exist(err);
+        done();
+      });
+    });
+
+    it('should generate testing stubs for the project successfully', function(done) {
+      var options = {pathName: '.*'};
+      project.generateTest(projPath, options, function(err) {
+        fs.existsSync(path.resolve(projPath, 'test/hello-test.js')).should.be.ok;
+        var packagePath = path.resolve(projPath, 'package.json');
+        fs.existsSync(packagePath).should.be.ok;
+        var packageJson = require(packagePath);
+        packageJson.devDependencies.hasOwnProperty('z-schema').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('request').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('chai').should.be.ok;
+        packageJson.devDependencies.hasOwnProperty('mocha').should.be.ok;
+        packageJson.hasOwnProperty('scripts').should.be.ok;
+        packageJson.scripts.hasOwnProperty('test').should.be.ok;
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
`generate-test` will use [swagger-test-templates](https://github.com/apigee-127/swagger-test-templates) to generate tests based on current project swagger spec.

Here is the generated manual:

```man
Usage: generate-test [options] [directory]

  Generate the test template

  Options:

    -h, --help                     output usage information
    -p, --path-name [path]         a sepecific path of the api, also suppport regular expression
    -f, --test-module <module>     one of: supertest|request
    -t, --assertion-format <type>  one of: expect|should|assert
```
//cc @noahdietz && @elsapeng