### PR TITLE
fix path to check for conflict files in generate-test

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -457,7 +457,7 @@ function testGenerate(directory, options, cb) {
           };
 
           var finalResult = template.testGen(result, config);
-          var existingFiles = fs.readdirSync(path.join(directory, 'test'));
+          var existingFiles = fs.readdirSync(path.join(directory, 'test/api/client'));
           var skipAll = false;
 
           async.filterSeries(finalResult, function(file, cb) {


### PR DESCRIPTION
Changed where generate-test looks for conflicts in existing files

@theganyo please take a look as soon as you can, thank you!