### PR TITLE
Expose swagger-test-templates load-testing API

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -74,7 +74,7 @@ app
   .option('-f, --test-module <module>', 'one of: ' + testmodules)
   .option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
   .option('-o, --force', 'allow overwriting of all existing test files matching those generated')
-  .option('-l, --load-test <path>', 'generate load-tests for specified operations')
+  .option('-l, --load-test [path]', 'generate load-tests for specified operations')
   .action(execute(project.generateTest));
 
 app.parse(process.argv);

--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -74,6 +74,7 @@ app
   .option('-f, --test-module <module>', 'one of: ' + testmodules)
   .option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
   .option('-o, --force', 'allow overwriting of all existing test files matching those generated')
+  .option('-l, --load-test [path]', 'generate load-tests for specified operations')
   .action(execute(project.generateTest));
 
 app.parse(process.argv);

--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -74,7 +74,7 @@ app
   .option('-f, --test-module <module>', 'one of: ' + testmodules)
   .option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
   .option('-o, --force', 'allow overwriting of all existing test files matching those generated')
-  .option('-l, --load-test [path]', 'generate load-tests for specified operations')
+  .option('-l, --load-test <path>', 'generate load-tests for specified operations')
   .action(execute(project.generateTest));
 
 app.parse(process.argv);

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -464,7 +464,7 @@ function testGenerate(directory, options, cb) {
             } else if (fs.existsSync(path.join(directory, 'load-config.json'))){
               config.loadTest = parseJsonFile(directory, 'load-config.json').loadTargets;
             } else {
-              return cb(new Error('Cannot find load testing configuration file'));
+              return cb(new Error('Config file not found. Please specify a load test config or add load-config.json file to your project directory.'));
             }
           }
 

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -458,8 +458,14 @@ function testGenerate(directory, options, cb) {
           };
 
           // pass list of paths targeted for load testing
-          if (loadTesting && fs.existsSync(path.join(directory, loadTesting))) {
-            config.loadTest = (JSON.parse(fs.readFileSync(path.join(directory, loadTesting)))).loadTargets;
+          if (loadTesting) {
+            if ((typeof loadTesting) !== 'boolean' && fs.existsSync(path.join(directory, loadTesting))) {
+              config.loadTest = (JSON.parse(fs.readFileSync(path.join(directory, loadTesting)))).loadTargets;
+            } else if (fs.existsSync(path.join(directory, 'load-config.json'))){
+              config.loadTest = (JSON.parse(fs.readFileSync(path.join(directory, 'load-config.json')))).loadTargets;
+            } else {
+              return cb(new Error('Cannot find load testing configuration file'));
+            }
           }
 
           var finalResult = template.testGen(result, config);

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -460,9 +460,9 @@ function testGenerate(directory, options, cb) {
           // pass list of paths targeted for load testing
           if (loadTesting) {
             if ((typeof loadTesting) !== 'boolean' && fs.existsSync(path.join(directory, loadTesting))) {
-              config.loadTest = (JSON.parse(fs.readFileSync(path.join(directory, loadTesting)))).loadTargets;
+              config.loadTest = parseJsonFile(directory, loadTesting).loadTargets;
             } else if (fs.existsSync(path.join(directory, 'load-config.json'))){
-              config.loadTest = (JSON.parse(fs.readFileSync(path.join(directory, 'load-config.json')))).loadTargets;
+              config.loadTest = parseJsonFile(directory, 'load-config.json').loadTargets;
             } else {
               return cb(new Error('Cannot find load testing configuration file'));
             }
@@ -538,6 +538,10 @@ function testGenerate(directory, options, cb) {
       });
     });
   });
+}
+
+function parseJsonFile(directory, filePath) {
+  return JSON.parse(fs.readFileSync(path.join(directory, filePath)));
 }
 
 function installDependencies(directory, message, cb) {

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -399,6 +399,7 @@ function testGenerate(directory, options, cb) {
   var testModule = options.testModule || TEST_MODULES[0];
   var assertionFormat = options.assertionFormat || TEST_ASSERTION_TYPES[0];
   var overwriteAll = options.force || false;
+  var loadTesting = options.loadTest || false;
   directory = directory || process.cwd();
 
   findProjectFile(directory, null, function(err, projPath) {
@@ -455,6 +456,11 @@ function testGenerate(directory, options, cb) {
             testModule: testModule,
             assertionFormat: assertionFormat
           };
+
+          // pass list of paths targeted for load testing
+          if (loadTesting && fs.existsSync(path.join(directory, loadTesting))) {
+            config.loadTest = (JSON.parse(fs.readFileSync(path.join(directory, loadTesting)))).loadTargets;
+          }
 
           var finalResult = template.testGen(result, config);
           var existingFiles = fs.readdirSync(path.join(directory, 'test/api/client'));

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "serve-static": "^1.9.2",
     "swagger-converter": "^0.1.7",
     "swagger-editor": "^2.9.2",
-    "swagger-test-templates": "^1.1.0",
+    "swagger-test-templates": "^1.2.0",
     "swagger-tools": "^0.9.0"
   },
   "devDependencies": {

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -516,7 +516,35 @@ describe('project', function() {
       });
     });
 
-    it ('should create load tests without error', function(done) {
+    it ('should create load tests from myLoadTest.json', function(done) {
+      var loadTargets = {
+        "loadTargets": [
+          {
+            "pathName":"/hello",
+            "operation": "get",
+            "load": {
+              "requests": 1000,
+              "concurrent": 100
+            }
+          }
+        ]
+      };
+
+      fs.writeFileSync(path.join(projPath, 'myLoadTest.json'), JSON.stringify(loadTargets));
+
+      var options = {loadTest: './myLoadTest.json', force: true};
+
+      project.generateTest(projPath, options, function(err) {
+        fs.existsSync(path.resolve(projPath, 'test/api/client/test-test.js')).should.be.ok;
+        fs.existsSync(path.resolve(projPath, 'test/api/client/hello-test.js')).should.be.ok;
+        fs.readFile(path.resolve(projPath, 'test/api/client/hello-test.js'), {encoding: 'utf8'}, function(err, string) {
+          string.search('arete').should.be.ok;
+          done(err);
+        });
+      });
+    });
+
+    it ('should create load tests from load-config.json', function(done) {
       var loadTargets = {
         "loadTargets": [
           {
@@ -532,7 +560,7 @@ describe('project', function() {
 
       fs.writeFileSync(path.join(projPath, 'load-config.json'), JSON.stringify(loadTargets));
 
-      var options = {loadTest: './load-config.json', force: true};
+      var options = {loadTest: true, force: true};
 
       project.generateTest(projPath, options, function(err) {
         fs.existsSync(path.resolve(projPath, 'test/api/client/test-test.js')).should.be.ok;

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -515,6 +515,34 @@ describe('project', function() {
         });
       });
     });
+
+    it ('should create load tests without error', function(done) {
+      var loadTargets = {
+        "loadTargets": [
+          {
+            "pathName":"/hello",
+            "operation": "get",
+            "load": {
+              "requests": 1000,
+              "concurrent": 100
+            }
+          }
+        ]
+      };
+
+      fs.writeFileSync(path.join(projPath, 'load-config.json'), JSON.stringify(loadTargets));
+
+      var options = {loadTest: './load-config.json', force: true};
+
+      project.generateTest(projPath, options, function(err) {
+        fs.existsSync(path.resolve(projPath, 'test/api/client/test-test.js')).should.be.ok;
+        fs.existsSync(path.resolve(projPath, 'test/api/client/hello-test.js')).should.be.ok;
+        fs.readFile(path.resolve(projPath, 'test/api/client/hello-test.js'), {encoding: 'utf8'}, function(err, string) {
+          string.search('arete').should.be.ok;
+          done(err);
+        });
+      });
+    });
   });
 
 });


### PR DESCRIPTION
@theganyo @mohsen1 how should the interface work? Based on the API in [swagger-test-templates](https://github.com/apigee-127/swagger-test-templates/blob/master/README.md) how should the specified paths+operations be passed through the CLI? 

Can I suggest passing the path to a JSON object/file that reflects the array of objects outlined in the API?