### PR TITLE
Allow multiple extra node arguments to be passed

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -144,7 +144,7 @@ function start(directory, options, cb) {
       nodemonOpts.nodeArgs.push(debugArg);
     }
     if (options.nodeArgs) {
-      nodemonOpts.nodeArgs.push(options.nodeArgs)
+      nodemonOpts.nodeArgs = nodemonOpts.nodeArgs.concat(options.nodeArgs.split(' '));
     }
     // https://www.npmjs.com/package/cors
     nodemonOpts.env = {

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -200,6 +200,16 @@ describe('project', function() {
       });
     });
 
+    it('should pass multiple extra arguments separately', function(done) {
+      var options = { nodeArgs: '--harmony --harmony_destructuring' };
+      project.start(projPath, options, function(err) {
+        should.not.exist(err);
+        nodemonOpts.nodeArgs.should.containDeep(['--harmony', '--harmony_destructuring']);
+        done();
+      });
+    });
+
+
     it('should combine extra arguments with debug', function(done) {
       var options = { debug: true, nodeArgs: '--harmony' };
       project.start(projPath, options, function(err) {


### PR DESCRIPTION
Without this patch, invoking `swagger project start --node-args "--harmony --harmony_destructuring"` would fail because of passing `--harmony --harmony_destructuring ` as one argument to node(mon)