### PR TITLE
Fixes Issue #288 `project swagger test` does not exit with the correct exit code

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -221,7 +221,7 @@ function test(directory, options, cb) {
       process.env.swagger_mockMode = true;
     }
     mocha.run(function(failures) {
-      cb(null, failures);
+      process.exit(failures);
     });
   });
 }


### PR DESCRIPTION
https://github.com/swagger-api/swagger-node/issues/288

This particular bug prevents project swagger test from being able to be used in CI frameworks like travis, as they rely on the exit code to know if the tests have passed or failed.