### PR TITLE
Allow project.api.main override using "api.main" key in package.json

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -283,7 +283,7 @@ function readProject(directory, options, cb) {
     project.api.swagger = yaml.safeLoad(fs.readFileSync(project.api.swaggerFile, 'utf8'));
 
     project.api.name = project.name;
-    project.api.main = project.main;
+    project.api.main = project.api.main || project.main;
     project.api.host = project.api.swagger.host;
     project.api.basePath = project.api.swagger.basePath;
 


### PR DESCRIPTION
Maybe there is a better implementation, but there's my problem:

I want to export the SwaggerExpress middleware only, without starting an express in the main file