### PR TITLE
npm@3 support: fix swagger-editor dir path. Fixes #351

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -32,7 +32,7 @@ module.exports = config;
 
 config.swagger = {
   fileName: 'api/swagger/swagger.yaml',
-  editorDir: path.resolve(config.nodeModules, 'swagger-editor'),
+  editorDir: path.dirname(require.resolve('swagger-editor')),
   editorConfig: {
     analytics: { google: { id: null } },
     disableCodeGen: true,


### PR DESCRIPTION
See issue #351 