### PR TITLE
npm@3 support: fix swagger-editor dir path

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -32,7 +32,7 @@ module.exports = config;
 
 config.swagger = {
   fileName: 'api/swagger/swagger.yaml',
-  editorDir: path.resolve(config.nodeModules, 'swagger-editor'),
+  editorDir: path.dirname(require.resolve('swagger-editor')),
   editorConfig: {
     analytics: { google: { id: null } },
     disableCodeGen: true,


### PR DESCRIPTION
Fixes #351. Original PR #352 
 
The original pr needs rebase since the test was failing, so I made a new fork based on the latest master. 