### PR TITLE
Fix conflict with swagger-node-runner 0.1.0

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -72,7 +72,11 @@ _.each(process.env, function(value, key) {
         if (!configItem[subKey]) { configItem[subKey] = {}; }
         configItem = configItem[subKey];
       } else {
-        configItem[subKey] = value;
+        try {
+            configItem[subKey] = JSON.parse(value);
+          } catch (err) {
+            configItem[subKey] = value;
+          }
       }
     }
     debug('loaded env var: %s = %s', split.slice(1).join('.'), value);


### PR DESCRIPTION
As it seems we can't upgrade swagger-node-runner to 0.6.0, here is a fix for a conflict between swagger-node and the runner

You can't define a envvar starting by swagger_ because swagger-node is waiting for a value but the runner is waiting for a JSON.