### PR TITLE
Change from __dirname to process.cwd()

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -20,7 +20,7 @@ var _ = require('lodash');
 var debug = require('debug')('swagger');
 
 var config = {
-  rootDir: path.resolve(__dirname, '..'),
+  rootDir: process.cwd(),
   userHome: process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'],
   debug: !!process.env.DEBUG
 };


### PR DESCRIPTION
We're using swagger-node from Docker and are using a local copy of the swagger script from `./node_modules/.bin/swagger` to run `./node_modules/.bin/swagger project edit`. This doesn't serve `swagger-editor` correctly as `__dirname` resolves to `./node_modules/swagger` as this is where the script is running. We've made the above change to use `process.cwd()` so that we can reference swagger-editor correctly.