### PR TITLE
Default settings causing TypeError

### DIFF
--- a/project-skeletons/sails/config/default.yaml
+++ b/project-skeletons/sails/config/default.yaml
@@ -24,6 +24,7 @@ swagger:
     # pipe for all swagger-node controllers
     swagger_controllers:
       - onError: json_error_handler
+      - swagger_params_parser
       - cors
       - swagger_security
       - _swagger_validate


### PR DESCRIPTION
According to https://github.com/theganyo/swagger-node-runner/releases/tag/v0.6.0 `swagger_params_parser` needs to be added to `swagger_controllers` otherwise req.swagger.params returns `undefined`.

This occurred for me after running the default hello_world function which calls to `req.swagger.params.name.value`.
