### PR TITLE
Build fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/swagger-api/swagger-node.svg?branch=master)](https://travis-ci.org/swagger-api/swagger-node)
+[![Build Status](https://travis-ci.org/swagger-api/swagger-node.svg?branch=master)](https://travis-ci.org/swagger-api/swagger-node) 
 
 The `swagger` module provides tools for designing and building Swagger-compliant APIs entirely in Node.js. It integrates with popular Node.js servers, including Express, Hapi, Restify, and Sails, as well as any Connect-based middleware. With `swagger`, you can specify, build, and test your API from the very beginning, on your laptop. It allows you to change and iterate your design without rewriting the logic of your implementation.
 

--- a/config/index.js
+++ b/config/index.js
@@ -32,7 +32,7 @@ module.exports = config;
 
 config.swagger = {
   fileName: 'api/swagger/swagger.yaml',
-  editorDir: path.dirname(require.resolve('swagger-editor')),
+  editorDir: path.resolve(config.nodeModules, 'swagger-editor'),
   editorConfig: {
     analytics: { google: { id: null } },
     disableCodeGen: true,


### PR DESCRIPTION
The commit [103b833](https://github.com/swagger-api/swagger-node/commit/103b833894965655765e157edd5ae3ca819f5ee9) caused the build to fail because of changes made to `swagger-editor` module, that made requiring it throw an error.

reverting this commit solved the problem and the build passed :)
 