### PR TITLE
Fixes Issue #288 `project swagger test` does not exit with the correct exit code

### DIFF
--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -221,7 +221,7 @@ function test(directory, options, cb) {
       process.env.swagger_mockMode = true;
     }
     mocha.run(function(failures) {
-      cb(null, failures);
+        process.exit(failures);
     });
   });
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "connect": "^3.3.5",
     "debug": "^2.1.3",
     "fs-extra": "^0.24.0",
-    "inquirer": "^0.10.0",
+    "inquirer": "^2.0.0",
     "js-yaml": "^3.3.0",
     "lodash": "^3.10.0",
     "mocha": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "connect": "^3.3.5",
     "debug": "^2.1.3",
     "fs-extra": "^0.24.0",
-    "inquirer": "^2.0.0",
+    "inquirer": "^1.2.3",
     "js-yaml": "^3.3.0",
     "lodash": "^3.10.0",
     "mocha": "^2.2.1",

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -490,7 +490,7 @@ describe('project', function() {
       setTimeout(function () {
         stdin.send('n\n');
         stdin.send('n\n');
-      }, 5000);
+      }, 250);
 
       project.generateTest(projPath, {}, function(err) {
         fs.existsSync(path.resolve(projPath, 'test/api/client/hello-test.js')).should.be.ok;

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -453,7 +453,7 @@ describe('project', function() {
 
       var prevFile = fs.readFileSync(path.resolve(projPath, 'test/api/client/hello-test.js'), {encoding: 'utf8'});
 
-      process.nextTick(function mockResponse() {
+      setTimeout(function () {
         stdin.send('y\n');
         stdin.send('y\n');
       });

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -490,7 +490,7 @@ describe('project', function() {
       setTimeout(function () {
         stdin.send('n\n');
         stdin.send('n\n');
-      }, 250);
+      }, 5000);
 
       project.generateTest(projPath, {}, function(err) {
         fs.existsSync(path.resolve(projPath, 'test/api/client/hello-test.js')).should.be.ok;

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -453,10 +453,10 @@ describe('project', function() {
 
       var prevFile = fs.readFileSync(path.resolve(projPath, 'test/api/client/hello-test.js'), {encoding: 'utf8'});
 
-      setTimeout(function () {
+      setTimeout(function mockResponse() {
         stdin.send('y\n');
         stdin.send('y\n');
-      });
+      }, 250);
 
       project.generateTest(projPath, {}, function(err) {
         fs.existsSync(path.resolve(projPath, 'test/api/client/hello-test.js')).should.be.ok;

--- a/test/commands/project/project.js
+++ b/test/commands/project/project.js
@@ -456,6 +456,7 @@ describe('project', function() {
       setTimeout(function mockResponse() {
         stdin.send('y\n');
         stdin.send('y\n');
+        done();
       }, 250);
 
       project.generateTest(projPath, {}, function(err) {
@@ -490,6 +491,7 @@ describe('project', function() {
       setTimeout(function () {
         stdin.send('n\n');
         stdin.send('n\n');
+        done();
       }, 250);
 
       project.generateTest(projPath, {}, function(err) {
@@ -511,6 +513,7 @@ describe('project', function() {
 
       process.nextTick(function mockResponse() {
         stdin.send('a\n');
+        done();
       });
 
       project.generateTest(projPath, {}, function(err) {


### PR DESCRIPTION
Fixes Issue #288 by rebasing change done in #335 to current master commit.

Replaced callback by process.exit to comply with ci tools