### PR TITLE
"Hello World"-example should match its spec ( Fixes #476 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Code your API's business logic in Node.js.
 ```js
 function hello(req, res) {
     var name = req.swagger.params.name.value || 'stranger';
-    var hello = util.format('{ "message": "Hello, %s" }', name);
-    res.json(hello);
+    var hello = util.format('Hello, %s!', name);
+    res.json({ "message": hello });
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Code your API's business logic in Node.js.
 ```js
 function hello(req, res) {
     var name = req.swagger.params.name.value || 'stranger';
-    var hello = util.format('Hello, %s', name);
+    var hello = util.format('{ "message": "Hello, %s" }', name);
     res.json(hello);
 }
 ```
@@ -77,7 +77,7 @@ It just works!
 
 ```bash
 $ curl http://127.0.0.1:10010/hello?name=Scott
-"Hello, Scott!"
+{ "message": "Hello, Scott!" }
 ```
 
 # <a name="installation"></a>Installing the swagger module

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -35,8 +35,8 @@ Here is the `hello_world.js` implementation for the quick start example. It retr
     };
 
     function hello(req, res) {
-      var name = req.swagger.params.name.value;
-      var hello = name ? util.format('Hello, %s', name) : 'Hello, stranger!';
+      var name = req.swagger.params.name.value || 'stranger';
+      var hello = util.format('{ "message": "Hello, %s" }', name);
       res.json(hello);
     }
 ```

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -36,8 +36,8 @@ Here is the `hello_world.js` implementation for the quick start example. It retr
 
     function hello(req, res) {
       var name = req.swagger.params.name.value || 'stranger';
-      var hello = util.format('{ "message": "Hello, %s" }', name);
-      res.json(hello);
+      var hello = util.format('Hello, %s!', name);
+      res.json({ "message": hello });
     }
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,7 +42,7 @@ First, we create a new swagger project and test a simple "hello world" API.
 
     `curl http://127.0.0.1:10010/hello?name=Scott`  
 
-    And, you'll get back the response `Hello, Scott`.
+    And, you'll get back the response `{ "message": "Hello, Scott" }`.
 
 That's it - You have now created, started and tested your first API project with swagger! 
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,7 +42,7 @@ First, we create a new swagger project and test a simple "hello world" API.
 
     `curl http://127.0.0.1:10010/hello?name=Scott`  
 
-    And, you'll get back the response `{ "message": "Hello, Scott" }`.
+    And, you'll get back the response `{ "message": "Hello, Scott!" }`.
 
 That's it - You have now created, started and tested your first API project with swagger! 
 

--- a/project-skeletons/connect/api/controllers/hello_world.js
+++ b/project-skeletons/connect/api/controllers/hello_world.js
@@ -37,8 +37,8 @@ module.exports = {
 function hello(req, res) {
   // variables defined in the Swagger document can be referenced using req.swagger.params.{parameter_name}
   var name = req.swagger.params.name.value || 'stranger';
-  var hello = util.format('{ "message": "Hello, %s!" }', name);
+  var hello = util.format('Hello, %s!', name);
 
   // this sends back a JSON response which is a single string
-  res.json(hello);
+  res.json({ "message": hello });
 }

--- a/project-skeletons/connect/api/controllers/hello_world.js
+++ b/project-skeletons/connect/api/controllers/hello_world.js
@@ -37,7 +37,7 @@ module.exports = {
 function hello(req, res) {
   // variables defined in the Swagger document can be referenced using req.swagger.params.{parameter_name}
   var name = req.swagger.params.name.value || 'stranger';
-  var hello = util.format('Hello, %s!', name);
+  var hello = util.format('{ "message": "Hello, %s!" }', name);
 
   // this sends back a JSON response which is a single string
   res.json(hello);

--- a/project-skeletons/connect/test/api/controllers/hello_world.js
+++ b/project-skeletons/connect/test/api/controllers/hello_world.js
@@ -18,7 +18,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('Hello, stranger!');
+            res.body.should.eql('{ "message": "Hello, stranger!" }');
 
             done();
           });
@@ -35,7 +35,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('Hello, Scott!');
+            res.body.should.eql('{ "message": "Hello, Scott!" }');
 
             done();
           });

--- a/project-skeletons/connect/test/api/controllers/hello_world.js
+++ b/project-skeletons/connect/test/api/controllers/hello_world.js
@@ -18,7 +18,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('{ "message": "Hello, stranger!" }');
+            res.body.should.eql({ "message": "Hello, stranger!" });
 
             done();
           });
@@ -35,7 +35,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('{ "message": "Hello, Scott!" }');
+            res.body.should.eql({ "message": "Hello, Scott!" });
 
             done();
           });

--- a/project-skeletons/sails/api/controllers/hello_world.js
+++ b/project-skeletons/sails/api/controllers/hello_world.js
@@ -37,8 +37,8 @@ module.exports = {
 function hello(req, res) {
   // variables defined in the Swagger document can be referenced using req.swagger.params.{parameter_name}
   var name = req.swagger.params.name.value || 'stranger';
-  var hello = util.format('{ "message": "Hello, %s!" }', name);
+  var hello = util.format('Hello, %s!', name);
 
   // this sends back a JSON response which is a single string
-  res.json(hello);
+  res.json({ "message": hello });
 }

--- a/project-skeletons/sails/api/controllers/hello_world.js
+++ b/project-skeletons/sails/api/controllers/hello_world.js
@@ -37,7 +37,7 @@ module.exports = {
 function hello(req, res) {
   // variables defined in the Swagger document can be referenced using req.swagger.params.{parameter_name}
   var name = req.swagger.params.name.value || 'stranger';
-  var hello = util.format('Hello, %s!', name);
+  var hello = util.format('{ "message": "Hello, %s!" }', name);
 
   // this sends back a JSON response which is a single string
   res.json(hello);

--- a/project-skeletons/sails/test/api/controllers/hello_world.js
+++ b/project-skeletons/sails/test/api/controllers/hello_world.js
@@ -17,7 +17,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('Hello, stranger!');
+            res.body.should.eql('{ "message": "Hello, stranger!" }');
 
             done();
           });
@@ -34,7 +34,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('Hello, Scott!');
+            res.body.should.eql('{ "message": "Hello, Scott!" }');
 
             done();
           });

--- a/project-skeletons/sails/test/api/controllers/hello_world.js
+++ b/project-skeletons/sails/test/api/controllers/hello_world.js
@@ -17,7 +17,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('{ "message": "Hello, stranger!" }');
+            res.body.should.eql({ "message": "Hello, stranger!" });
 
             done();
           });
@@ -34,7 +34,7 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
 
-            res.body.should.eql('{ "message": "Hello, Scott!" }');
+            res.body.should.eql({ "message": "Hello, Scott!" });
 
             done();
           });

--- a/test/project-skeletons/common.js
+++ b/test/project-skeletons/common.js
@@ -89,7 +89,7 @@ function testFramework(framework) {
             debug('Result: %s %j', res.text, res.headers);
 
             res.status.should.eql(200);
-            res.body.should.eql('{ "message": "Hello, stranger!" }');
+            res.body.should.eql({ "message": "Hello, stranger!" });
 
             done();
           });

--- a/test/project-skeletons/common.js
+++ b/test/project-skeletons/common.js
@@ -104,7 +104,7 @@ function testFramework(framework) {
             debug('Result: %s %j', res.text, res.headers);
 
             res.status.should.eql(200);
-            res.body.should.eql('{ "message": "Hello, Scott!" }');
+            res.body.should.eql({ "message": "Hello, Scott!" });
 
             done();
           });

--- a/test/project-skeletons/common.js
+++ b/test/project-skeletons/common.js
@@ -89,7 +89,7 @@ function testFramework(framework) {
             debug('Result: %s %j', res.text, res.headers);
 
             res.status.should.eql(200);
-            res.body.should.eql('Hello, stranger!');
+            res.body.should.eql('{ "message": "Hello, stranger!" }');
 
             done();
           });
@@ -104,7 +104,7 @@ function testFramework(framework) {
             debug('Result: %s %j', res.text, res.headers);
 
             res.status.should.eql(200);
-            res.body.should.eql('Hello, Scott!');
+            res.body.should.eql('{ "message": "Hello, Scott!" }');
 
             done();
           });


### PR DESCRIPTION
Hi,

I just started experimenting with swagger and followed the steps in the Readme. 
When I generated a C#-Client for the "Hello World"-Example-Server, it wasn't working out of the box, because the server just returns "Hello, stranger" instead of "{ "message": "Hello, stranger" } as specified in the swagger-spec.
I first created an issue in the swagger-codegen-repo (see swagger-api/swagger-codegen#4816), which was the wrong place for reporting :)

This is only a minor bug I know, but the example should work out of the box. This pull request should make the example match its spec again. It should fix: #476