### PR TITLE
Update swagger-editor to support definitions with external references

### DIFF
--- a/lib/commands/project/swagger_editor.js
+++ b/lib/commands/project/swagger_editor.js
@@ -65,8 +65,10 @@ function edit(project, options, cb) {
 
   // serve swagger-editor
   app.use(SWAGGER_EDITOR_SERVE_PATH, serveStatic(config.swagger.editorDir));
-
-
+  
+  // Serve the references of the definition file
+  app.use("/", serveStatic(path.dirname(swaggerFile)));
+ 
   // start //
 
   var http = require('http');


### PR DESCRIPTION
Serve files from the swagger yaml's directory, so they can be included.