### PR TITLE
Rspec BDD Generation

### DIFF
--- a/bin/swagger-project.js
+++ b/bin/swagger-project.js
@@ -23,6 +23,7 @@ var execute = cli.execute;
 var frameworks = Object.keys(project.frameworks).join('|');
 var assertiontypes = project.assertiontypes.join('|');
 var testmodules = project.testmodules.join('|');
+var lang = project.lang.join('|');
 
 app
   .command('create [name]')
@@ -65,6 +66,7 @@ app
   .option('-d, --debug [port]', 'start in remote debug mode')
   .option('-b, --debug-brk [port]', 'start in remote debug mode, wait for debugger connect')
   .option('-m, --mock', 'run in mock mode')
+  .option('-o, --host <server>', 'test server')
   .action(execute(project.test));
 
 app
@@ -75,6 +77,7 @@ app
   .option('-t, --assertion-format <type>', 'one of: ' + assertiontypes)
   .option('-o, --force', 'allow overwriting of all existing test files matching those generated')
   .option('-l, --load-test [path]', 'generate load-tests for specified operations')
+  .option('-n, --lang <language>', 'one of: ' + lang)
   .action(execute(project.generateTest));
 
 app.parse(process.argv);

--- a/config/index.js
+++ b/config/index.js
@@ -22,7 +22,8 @@ var debug = require('debug')('swagger');
 var config = {
   rootDir: path.resolve(__dirname, '..'),
   userHome: process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'],
-  debug: !!process.env.DEBUG
+  debug: !!process.env.DEBUG,
+  language: 'js'
 };
 config.nodeModules = path.resolve(config.rootDir, 'node_modules');
 

--- a/lib/commands/project/project.js
+++ b/lib/commands/project/project.js
@@ -30,6 +30,7 @@ var swaggerSpec = require('../../util/spec');
 var spec = require('swagger-tools').specs.v2;
 var inquirer = require('inquirer');
 
+var LANGUAGE = ['js', 'rb'];
 var FRAMEWORKS = {
   connect: { source: 'connect' },
   express: { source: 'connect', overlay: 'express' },
@@ -61,6 +62,8 @@ module.exports = {
   read: readProject,
   assertiontypes: TEST_ASSERTION_TYPES,
   testmodules: TEST_MODULES,
+  lang: LANGUAGE,
+
 
   // for testing stub generating
   generateTest: testGenerate
@@ -77,8 +80,9 @@ function create(name, options, cb) {
   }
 
   if (name) {
-    var valid = validateName(name);
-    if (typeof valid === 'string') { return cb(new Error(valid)); }
+      var valid = validateName(name);
+      if (typeof valid === 'string') { return cb(new Error(valid)); }
+
   }
 
   if (options.framework && !FRAMEWORKS[options.framework]) {
@@ -220,6 +224,14 @@ function test(directory, options, cb) {
     if (options.mock) {
       process.env.swagger_mockMode = true;
     }
+
+    var server_config = require('../../../../../config.json')
+    process.env.swagger_host = server_config[options.host].protocol + "://";
+    process.env.swagger_host += server_config[options.host].host;
+    if(server_config[options.host].port != ""){
+        process.env.swagger_host += ":" + server_config[options.host].port;
+    }
+
     mocha.run(function(failures) {
         process.exit(failures);
     });
@@ -456,7 +468,8 @@ function testGenerate(directory, options, cb) {
           var config = {
             pathName: desiredPaths,
             testModule: testModule,
-            assertionFormat: assertionFormat
+            assertionFormat: assertionFormat,
+            lang: options.lang
           };
 
           // pass list of paths targeted for load testing
@@ -523,18 +536,9 @@ function testGenerate(directory, options, cb) {
               }
             }
           }, function(filteredResult) {
-
-            async.each(filteredResult, function(file, cb) {
-              if (file.name === '.env') {
-                fs.outputFile(path.join(directory, file.name), file.test, cb);
-              } else {
-                fs.outputFile(path.join(directory, '/test/api/client', file.name), file.test, cb);
-              }
-            }, function(err) {
-              if (runInstall) {
-                installDependencies(directory, 'Success! You may now run your tests.', cb);
-              }
-            });
+            finalResult.forEach(function(file){
+		            fs.outputFile(path.join(directory,'/test/api/client', file.name), file.test.replace(/x-enum/g, "enum"), cb);
+		            });
           });
         });
       });


### PR DESCRIPTION
I have added support for rspec generation from the swagger-test-templates module available at my forked repository of the swagger-test-templates. A command-line arg for language is used to invoke the required template and the use of local config files is also made possible for both the js and rspec generated.
