### PR TITLE
Move mocha to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "inquirer": "^1.2.3",
     "js-yaml": "^3.3.0",
     "lodash": "^4.17.2",
-    "mocha": "^3.2.0",
     "nodemon": "^1.3.7",
     "serve-static": "^1.9.2",
     "swagger-converter": "^1.4.1",
@@ -36,6 +35,7 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
+    "mocha": "^3.2.0",
     "mock-stdin": "^0.3.0",
     "proxyquire": "^1.4.0",
     "should": "^11.1.1",


### PR DESCRIPTION
[`mocha`](https://www.npmjs.com/package/mocha) is a testing framework, so it shouldn't be needed outside of `devdependencies`.

Having fewer `dependencies` obviously pulls in less dependencies, for those who use `swagger` in their project. That makes for a lighter `node_modules` folder, less things to keep up-to-date to satisfy `npm audit` and `yarn audit`, etc...

I hope this is simple and easy-to-review enough to be included in a maintenance release?